### PR TITLE
Create Python installation: Linux

### DIFF
--- a/Python installation: Linux
+++ b/Python installation: Linux
@@ -1,0 +1,28 @@
+To install Python 3 on Linux
+
+    See if Python is already installed.
+
+    $ python --version
+
+    or
+
+    $ python3 --version
+
+    Note
+
+    If your Linux distribution came with Python, you might need to install the Python developer package to get the headers and libraries required to compile extensions, and install the AWS CLI. Use your package manager to install the developer package (typically named python-dev or python-devel).
+
+    If Python 2.7 or later is not installed, install Python with your distribution's package manager. The command and package name varies:
+
+        On Debian derivatives such as Ubuntu, use apt. Check the apt repository for the versions of Python available to you. Then, run a command similar to the following, substituting the correct package name:
+
+        $ sudo apt-get install python3
+
+        On Red Hat and derivatives, use yum. Check the yum repository for the versions of Python available to you. Then, run a command similar to the following, substituting the correct package name:
+
+        $ sudo yum install python36
+
+        On SUSE and derivatives, use zypper. Check the repository for the versions of Python available to you. Then. run a command similar to the following, substituting the correct package name:
+
+        $ sudo zypper install python3
+


### PR DESCRIPTION
To install Python 3 on Linux

    See if Python is already installed.

    $ python --version

    or

    $ python3 --version

    Note

    If your Linux distribution came with Python, you might need to install the Python developer package to get the headers and libraries required to compile extensions, and install the AWS CLI. Use your package manager to install the developer package (typically named python-dev or python-devel).

    If Python 2.7 or later is not installed, install Python with your distribution's package manager. The command and package name varies:

        On Debian derivatives such as Ubuntu, use apt. Check the apt repository for the versions of Python available to you. Then, run a command similar to the following, substituting the correct package name:

        $ sudo apt-get install python3

        On Red Hat and derivatives, use yum. Check the yum repository for the versions of Python available to you. Then, run a command similar to the following, substituting the correct package name:

        $ sudo yum install python36

        On SUSE and derivatives, use zypper. Check the repository for the versions of Python available to you. Then. run a command similar to the following, substituting the correct package name:

        $ sudo zypper install python3

